### PR TITLE
Consistent version numbers

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -26,6 +26,6 @@ jobs:
           update-script: |
             VERSION=$(
               curl -sL https://api.github.com/repos/anchore/syft/releases | 
-              jq .  | grep tag_name | grep -v beta | head -n 1 | cut -d'"' -f4 | tr -d 'v'
+              jq .  | grep tag_name | grep -v beta | head -n 1 | cut -d'"' -f4
             )
             sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: syft
 base: core24
-version: 1.10.0
+version: "v1.10.0"
 summary: SBOM Generator
 description: |
   CLI tool and library for generating a Software Bill of Materials from container
@@ -32,9 +32,7 @@ confinement: classic
 parts:
   syft:
     plugin: go
-    source: https://github.com/anchore/syft.git
-    source-type: git
-    source-tag: 'v1.9.0'
+    source: https://github.com/anchore/$SNAPCRAFT_PROJECT_NAME/archive/refs/tags/$SNAPCRAFT_PROJECT_VERSION.tar.gz
     prime:
       - bin/syft
     build-snaps:


### PR DESCRIPTION
Updates the build action to ensure the version is in sync with upstream, preserving the 'v'.